### PR TITLE
Added media filters for description_long to convert media markup.

### DIFF
--- a/ding_place2book.module
+++ b/ding_place2book.module
@@ -551,7 +551,7 @@ function place2book_build_xml($node, $service_settings) {
 
   // Set long description.
   $field_ding_event_body = field_get_items('node', $node, 'field_ding_event_body');
-  $xml->event->description_long = $field_ding_event_body[0]['value'];
+  $xml->event->description_long = media_filter($field_ding_event_body[0]['value']);
 
   // Set sales window times empty - and they will use the defaults in place2book.
   $xml->event->sale_open = '';


### PR DESCRIPTION
Long description media tags are not converted and therefore images don't show up in kultunaut body field.
