### PR TITLE
Added media filter for description_long (body wysiwyg) to convert media ...

### DIFF
--- a/ding_place2book.module
+++ b/ding_place2book.module
@@ -552,7 +552,7 @@ function place2book_build_xml($node, $service_settings) {
 
   // Set long description.
   $field_ding_event_body = field_get_items('node', $node, 'field_ding_event_body');
-  $xml->event->description_long = $field_ding_event_body[0]['value'];
+  $xml->event->description_long = media_filter($field_ding_event_body[0]['value']);
 
   // Set sales window times empty - and they will use the defaults in place2book.
   $xml->event->sale_open = '';


### PR DESCRIPTION
...markup. description_long (Body wysiwyg) media tags is not converted during XML export and therefore images from description_long will not be shown on Kultunaut.
